### PR TITLE
Format Files according to pep8

### DIFF
--- a/objectbox/box.py
+++ b/objectbox/box.py
@@ -92,10 +92,12 @@ class Box:
                 key = ctypes.c_size_t(k)
 
                 # OBX_bytes_array.data[k] = data
-                obx_bytes_array_set(c_bytes_array_p, key, data[k], len(data[k]))
+                obx_bytes_array_set(c_bytes_array_p, key,
+                                    data[k], len(data[k]))
 
             c_ids = (obx_id * len(ids))(*ids.values())
-            obx_box_put_many(self._c_box, c_bytes_array_p, c_ids, OBXPutMode_PUT)
+            obx_box_put_many(self._c_box, c_bytes_array_p,
+                             c_ids, OBXPutMode_PUT)
 
         finally:
             obx_bytes_array_free(c_bytes_array_p)
@@ -108,7 +110,8 @@ class Box:
         with self._ob.read_tx():
             c_data = ctypes.c_void_p()
             c_size = ctypes.c_size_t()
-            obx_box_get(self._c_box, id, ctypes.byref(c_data), ctypes.byref(c_size))
+            obx_box_get(self._c_box, id, ctypes.byref(
+                c_data), ctypes.byref(c_size))
 
             data = c_voidp_as_bytes(c_data, c_size.value)
             return self._entity.unmarshal(data)

--- a/objectbox/c.py
+++ b/objectbox/c.py
@@ -231,7 +231,6 @@ def fn(name: str, restype: type, argtypes):
 
     if restype is obx_err:
         func.errcheck = check_obx_err
-        pass
     elif restype is not None:
         func.errcheck = check_result
 

--- a/objectbox/c.py
+++ b/objectbox/c.py
@@ -41,21 +41,23 @@ def shlib_name(library: str) -> str:
 
 # initialize the C library
 lib_path = os.path.dirname(os.path.realpath(__file__))
-lib_path = os.path.join(lib_path, 'lib', \
-    platform.machine() if platform.system() != 'Darwin' else 'macos-universal', shlib_name('objectbox'))
+lib_path = os.path.join(lib_path, 'lib',
+                        platform.machine() if platform.system() != 'Darwin' else 'macos-universal', shlib_name('objectbox'))
 C = ctypes.CDLL(lib_path)
 
 # load the core library version
 __major = ctypes.c_int(0)
 __minor = ctypes.c_int(0)
 __patch = ctypes.c_int(0)
-C.obx_version(ctypes.byref(__major), ctypes.byref(__minor), ctypes.byref(__patch))
+C.obx_version(ctypes.byref(__major), ctypes.byref(
+    __minor), ctypes.byref(__patch))
 
 # C-api (core library) version
 version_core = Version(__major.value, __minor.value, __patch.value)
 
 assert str(version_core) == required_version, \
-    "Incorrect ObjectBox version loaded: %s instead of expected %s " % (str(version_core), required_version)
+    "Incorrect ObjectBox version loaded: %s instead of expected %s " % (
+        str(version_core), required_version)
 
 # define some basic types
 obx_err = ctypes.c_int
@@ -195,7 +197,8 @@ class CoreException(Exception):
         self.code = code
         self.message = py_str(C.obx_last_error_message())
         name = self.codes[code] if code in self.codes else "n/a"
-        super(CoreException, self).__init__("%d (%s) - %s" % (code, name, self.message))
+        super(CoreException, self).__init__(
+            "%d (%s) - %s" % (code, name, self.message))
 
 
 class NotFoundException(Exception):
@@ -257,23 +260,28 @@ def c_voidp_as_bytes(voidp, size):
 obx_model = fn('obx_model', OBX_model_p, [])
 
 # obx_err (OBX_model* model, const char* name, obx_schema_id entity_id, obx_uid entity_uid);
-obx_model_entity = fn('obx_model_entity', obx_err, [OBX_model_p, ctypes.c_char_p, obx_schema_id, obx_uid])
+obx_model_entity = fn('obx_model_entity', obx_err, [
+                      OBX_model_p, ctypes.c_char_p, obx_schema_id, obx_uid])
 
 # obx_err (OBX_model* model, const char* name, OBXPropertyType type, obx_schema_id property_id, obx_uid property_uid);
 obx_model_property = fn('obx_model_property', obx_err,
                         [OBX_model_p, ctypes.c_char_p, OBXPropertyType, obx_schema_id, obx_uid])
 
 # obx_err (OBX_model* model, OBXPropertyFlags flags);
-obx_model_property_flags = fn('obx_model_property_flags', obx_err, [OBX_model_p, OBXPropertyFlags])
+obx_model_property_flags = fn('obx_model_property_flags', obx_err, [
+                              OBX_model_p, OBXPropertyFlags])
 
 # obx_err (OBX_model*, obx_schema_id entity_id, obx_uid entity_uid);
-obx_model_last_entity_id = fn('obx_model_last_entity_id', None, [OBX_model_p, obx_schema_id, obx_uid])
+obx_model_last_entity_id = fn('obx_model_last_entity_id', None, [
+                              OBX_model_p, obx_schema_id, obx_uid])
 
 # obx_err (OBX_model* model, obx_schema_id index_id, obx_uid index_uid);
-obx_model_last_index_id = fn('obx_model_last_index_id', None, [OBX_model_p, obx_schema_id, obx_uid])
+obx_model_last_index_id = fn('obx_model_last_index_id', None, [
+                             OBX_model_p, obx_schema_id, obx_uid])
 
 # obx_err (OBX_model* model, obx_schema_id relation_id, obx_uid relation_uid);
-obx_model_last_relation_id = fn('obx_model_last_relation_id', None, [OBX_model_p, obx_schema_id, obx_uid])
+obx_model_last_relation_id = fn('obx_model_last_relation_id', None, [
+                                OBX_model_p, obx_schema_id, obx_uid])
 
 # obx_err (OBX_model* model, obx_schema_id property_id, obx_uid property_uid);
 obx_model_entity_last_property_id = fn('obx_model_entity_last_property_id', obx_err,
@@ -283,19 +291,24 @@ obx_model_entity_last_property_id = fn('obx_model_entity_last_property_id', obx_
 obx_opt = fn('obx_opt', OBX_store_options_p, [])
 
 # obx_err (OBX_store_options* opt, const char* dir);
-obx_opt_directory = fn('obx_opt_directory', obx_err, [OBX_store_options_p, ctypes.c_char_p])
+obx_opt_directory = fn('obx_opt_directory', obx_err, [
+                       OBX_store_options_p, ctypes.c_char_p])
 
 # void (OBX_store_options* opt, size_t size_in_kb);
-obx_opt_max_db_size_in_kb = fn('obx_opt_max_db_size_in_kb', None, [OBX_store_options_p, ctypes.c_size_t])
+obx_opt_max_db_size_in_kb = fn('obx_opt_max_db_size_in_kb', None, [
+                               OBX_store_options_p, ctypes.c_size_t])
 
 # void (OBX_store_options* opt, int file_mode);
-obx_opt_file_mode = fn('obx_opt_file_mode', None, [OBX_store_options_p, ctypes.c_uint])
+obx_opt_file_mode = fn('obx_opt_file_mode', None, [
+                       OBX_store_options_p, ctypes.c_uint])
 
 # void (OBX_store_options* opt, int max_readers);
-obx_opt_max_readers = fn('obx_opt_max_readers', None, [OBX_store_options_p, ctypes.c_uint])
+obx_opt_max_readers = fn('obx_opt_max_readers', None, [
+                         OBX_store_options_p, ctypes.c_uint])
 
 # obx_err (OBX_store_options* opt, OBX_model* model);
-obx_opt_model = fn('obx_opt_model', obx_err, [OBX_store_options_p, OBX_model_p])
+obx_opt_model = fn('obx_opt_model', obx_err, [
+                   OBX_store_options_p, OBX_model_p])
 
 # void (OBX_store_options* opt);
 obx_opt_free = fn('obx_opt_free', None, [OBX_store_options_p])
@@ -335,25 +348,31 @@ obx_box_get_all = fn('obx_box_get_all', OBX_bytes_array_p, [OBX_box_p])
 obx_box_id_for_put = fn('obx_box_id_for_put', obx_id, [OBX_box_p, obx_id])
 
 # obx_err (OBX_box* box, uint64_t count, obx_id* out_first_id);
-obx_box_ids_for_put = fn('obx_box_ids_for_put', obx_err, [OBX_box_p, ctypes.c_uint64, ctypes.POINTER(obx_id)])
+obx_box_ids_for_put = fn('obx_box_ids_for_put', obx_err, [
+                         OBX_box_p, ctypes.c_uint64, ctypes.POINTER(obx_id)])
 
 # obx_err (OBX_box* box, obx_id id, const void* data, size_t size);
-obx_box_put = fn('obx_box_put', obx_err, [OBX_box_p, obx_id, ctypes.c_void_p, ctypes.c_size_t])
+obx_box_put = fn('obx_box_put', obx_err, [
+                 OBX_box_p, obx_id, ctypes.c_void_p, ctypes.c_size_t])
 
 # obx_err (OBX_box* box, const OBX_bytes_array* objects, const obx_id* ids, OBXPutMode mode);
-obx_box_put_many = fn('obx_box_put_many', obx_err, [OBX_box_p, OBX_bytes_array_p, ctypes.POINTER(obx_id), OBXPutMode])
+obx_box_put_many = fn('obx_box_put_many', obx_err, [
+                      OBX_box_p, OBX_bytes_array_p, ctypes.POINTER(obx_id), OBXPutMode])
 
 # obx_err (OBX_box* box, obx_id id);
 obx_box_remove = fn('obx_box_remove', obx_err, [OBX_box_p, obx_id])
 
 # obx_err (OBX_box* box, uint64_t* out_count);
-obx_box_remove_all = fn('obx_box_remove_all', obx_err, [OBX_box_p, ctypes.POINTER(ctypes.c_uint64)])
+obx_box_remove_all = fn('obx_box_remove_all', obx_err, [
+                        OBX_box_p, ctypes.POINTER(ctypes.c_uint64)])
 
 # obx_err (OBX_box* box, bool* out_is_empty);
-obx_box_is_empty = fn('obx_box_is_empty', obx_err, [OBX_box_p, ctypes.POINTER(ctypes.c_bool)])
+obx_box_is_empty = fn('obx_box_is_empty', obx_err, [
+                      OBX_box_p, ctypes.POINTER(ctypes.c_bool)])
 
 # obx_err obx_box_count(OBX_box* box, uint64_t limit, uint64_t* out_count);
-obx_box_count = fn('obx_box_count', obx_err, [OBX_box_p, ctypes.c_uint64, ctypes.POINTER(ctypes.c_uint64)])
+obx_box_count = fn('obx_box_count', obx_err, [
+                   OBX_box_p, ctypes.c_uint64, ctypes.POINTER(ctypes.c_uint64)])
 
 # OBX_bytes_array* (size_t count);
 obx_bytes_array = fn('obx_bytes_array', OBX_bytes_array_p, [ctypes.c_size_t])

--- a/objectbox/model/entity.py
+++ b/objectbox/model/entity.py
@@ -23,10 +23,12 @@ class _Entity(object):
     def __init__(self, cls, id: int, uid: int):
         # currently, ID and UID are mandatory and are not fetched from the model.json
         if id <= 0:
-            raise Exception("invalid or no 'id; given in the @Entity annotation")
+            raise Exception(
+                "invalid or no 'id; given in the @Entity annotation")
 
         if uid <= 0:
-            raise Exception("invalid or no 'uid' given in the @Entity annotation")
+            raise Exception(
+                "invalid or no 'uid' given in the @Entity annotation")
 
         self.cls = cls
         self.name = cls.__name__
@@ -48,7 +50,8 @@ class _Entity(object):
         variables = dict(vars(self.cls))
 
         # filter only subclasses of Property
-        variables = {k: v for k, v in variables.items() if issubclass(type(v), Property)}
+        variables = {k: v for k, v in variables.items(
+        ) if issubclass(type(v), Property)}
 
         for k, prop in variables.items():
             prop._name = k
@@ -56,7 +59,8 @@ class _Entity(object):
 
             if prop._is_id:
                 if self.id_property:
-                    raise Exception("duplicate ID property: '%s' and '%s'" % (self.id_property._name, prop._name))
+                    raise Exception("duplicate ID property: '%s' and '%s'" % (
+                        self.id_property._name, prop._name))
                 self.id_property = prop
 
             if prop._fb_type == flatbuffers.number_types.UOffsetTFlags:
@@ -106,7 +110,8 @@ class _Entity(object):
                 if val:
                     builder.PrependUOffsetTRelative(val)
             else:
-                val = id if prop == self.id_property else self.get_value(object, prop)
+                val = id if prop == self.id_property else self.get_value(
+                    object, prop)
                 builder.Prepend(prop._fb_type, val)
 
             builder.Slot(prop._fb_slot)

--- a/objectbox/model/model.py
+++ b/objectbox/model/model.py
@@ -43,22 +43,28 @@ class Model:
 
         entity.last_property_id = last_property_id
 
-        obx_model_entity(self._c_model, c_str(entity.name), entity.id, entity.uid)
+        obx_model_entity(self._c_model, c_str(
+            entity.name), entity.id, entity.uid)
 
         for v in entity.properties:
-            obx_model_property(self._c_model, c_str(v._name), v._ob_type, v._id, v._uid)
+            obx_model_property(self._c_model, c_str(
+                v._name), v._ob_type, v._id, v._uid)
             if v._flags != 0:
                 obx_model_property_flags(self._c_model, v._flags)
 
-        obx_model_entity_last_property_id(self._c_model, last_property_id.id, last_property_id.uid)
+        obx_model_entity_last_property_id(
+            self._c_model, last_property_id.id, last_property_id.uid)
 
     # called by Builder
     def _finish(self):
         if self.last_relation_id:
-            obx_model_last_relation_id(self._c_model, self.last_relation_id.id, self.last_relation_id.uid)
+            obx_model_last_relation_id(
+                self._c_model, self.last_relation_id.id, self.last_relation_id.uid)
 
         if self.last_index_id:
-            obx_model_last_index_id(self._c_model, self.last_index_id.id, self.last_index_id.uid)
+            obx_model_last_index_id(
+                self._c_model, self.last_index_id.id, self.last_index_id.uid)
 
         if self.last_entity_id:
-            obx_model_last_entity_id(self._c_model, self.last_entity_id.id, self.last_entity_id.uid)
+            obx_model_last_entity_id(
+                self._c_model, self.last_entity_id.id, self.last_entity_id.uid)

--- a/objectbox/objectbox.py
+++ b/objectbox/objectbox.py
@@ -16,6 +16,7 @@
 from objectbox.c import *
 import objectbox.transaction
 
+
 class ObjectBox:
     def __init__(self, c_store: OBX_store_p):
         self._c_store = c_store
@@ -28,4 +29,3 @@ class ObjectBox:
 
     def write_tx(self):
         return objectbox.transaction.write(self)
-


### PR DESCRIPTION
Formatted the Files via VSCode Format with autopep8 package and remove one unnecessary "pass" keyword.
Originally wanted to fix #6, but it was already fixed.