### PR TITLE
Actions: drop virtual env install, enable pip cache.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,11 +20,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
+          cache: 'pip'
 
       - name: Prepare environment
         run: |
           python -m pip install --upgrade pip
-          pip install virtualenv
 
       - run: make depend
       - run: make test


### PR DESCRIPTION
To avoid some downloads from runners.

However, still seem to be hitting limits.