### PR TITLE
fix: correct entity field syntax in README code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ from objectbox import Entity, Id, Store, String
 
 @Entity()
 class Person:
-    id = Id
-    name = String
+    id = Id()
+    name = String()
 
 # The ObjectBox Store represents a database; keep it around...
 store = Store()


### PR DESCRIPTION
## Problem

The CRUD code example in `README.md` uses `Id` and `String` as class attributes **without parentheses**:

```python
@Entity()
class Person:
    id = Id      # ❌ wrong
    name = String  # ❌ wrong
```

When a user copies this code and tries to instantiate `Person(name="Joe Green")`, they get a `TypeError` at runtime because `Id` and `String` are descriptor classes that must be **instantiated** (called with `()`) to work correctly as field definitions.

This was originally reported in issue #10 back in 2021 and has been confirmed by multiple users since then.

## Fix

Added the missing parentheses to both field definitions:

```python
@Entity()
class Person:
    id = Id()       # ✅ correct
    name = String() # ✅ correct
```

This matches the syntax used throughout the actual [example code](https://github.com/objectbox/objectbox-python/tree/main/example/tasks/main.py) in the repository.

Fixes #10

---

> **About the contributor:** I'm a developer passionate about open source and always looking for opportunities to contribute and grow. If you're looking for collaborators or have open positions, feel free to reach out!
> - 🔗 LinkedIn: https://www.linkedin.com/in/elizio-martins/
> - 📧 E-mail: elizio.matins@gmail.com